### PR TITLE
Comment out debug logs of collection views

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-gallery.tsx
+++ b/packages/react-notion-x/src/components/collection-view-gallery.tsx
@@ -18,7 +18,7 @@ export const CollectionViewGallery: React.FC<CollectionViewProps> = ({
     gallery_cover_aspect = 'cover'
   } = collectionView.format || {}
 
-  console.log('gallery', { collection, collectionView, collectionData })
+  // console.log('gallery', { collection, collectionView, collectionData })
 
   return (
     <div className='notion-gallery'>

--- a/packages/react-notion-x/src/components/collection-view-table.tsx
+++ b/packages/react-notion-x/src/components/collection-view-table.tsx
@@ -14,7 +14,7 @@ export const CollectionViewTable: React.FC<CollectionViewProps> = ({
   width
 }) => {
   const { recordMap } = useNotionContext()
-  console.log('table', { collection, collectionView, collectionData })
+  // console.log('table', { collection, collectionView, collectionData })
 
   let properties = []
 


### PR DESCRIPTION
Not sure it is intended, collection view components print out some debugging info on browsers or server logs. Hope it is able to control its verbose level in the future. Gently suggesting commenting those out in production.